### PR TITLE
Fix tile display in new SmartThings app

### DIFF
--- a/devicetypes/xtreme22886/unifi-presence-sensor.src/unifi-presence-sensor.groovy
+++ b/devicetypes/xtreme22886/unifi-presence-sensor.src/unifi-presence-sensor.groovy
@@ -18,6 +18,7 @@ metadata {
 	definition (name: "UniFi Presence Sensor", namespace: "xtreme22886", author: "xtreme", ocfDeviceType: "x.com.st.d.sensor.presence") {
 		capability "Presence Sensor"
 		capability "Sensor"
+        command "setPresence"
 	}
 
 	tiles {
@@ -36,4 +37,5 @@ def setPresence(status) {
 	} else {
 		status = "present"
 	}
+    sendEvent(name: "presence", value: status)
 }

--- a/devicetypes/xtreme22886/unifi-presence-sensor.src/unifi-presence-sensor.groovy
+++ b/devicetypes/xtreme22886/unifi-presence-sensor.src/unifi-presence-sensor.groovy
@@ -18,7 +18,7 @@ metadata {
 	definition (name: "UniFi Presence Sensor", namespace: "xtreme22886", author: "xtreme", ocfDeviceType: "x.com.st.d.sensor.presence") {
 		capability "Presence Sensor"
 		capability "Sensor"
-        command "setPresence"
+		command "setPresence"
 	}
 
 	tiles {


### PR DESCRIPTION
Just a small change that fixes the tile display in the new SmartThings app. Without this the tiles were displaying status as a number "0" and when clicking into it, it would display as though it was broken. This fixes both issues.